### PR TITLE
change directory mode before deleting them.

### DIFF
--- a/rdiff-backup/rdiff_backup/log.py
+++ b/rdiff-backup/rdiff_backup/log.py
@@ -19,7 +19,7 @@
 
 """Manage logging, displaying and recording messages with required verbosity"""
 
-import time, sys, traceback, types, rpath
+import time, sys, traceback, types, rpath, locale
 import Globals, static, re
 
 
@@ -139,12 +139,18 @@ class Logger:
 		else: termfp = sys.stdout
 		str = self.format(message, self.term_verbosity)
 		if type(str) != unicode:
-			str = unicode(str, 'utf-8')
+			try:
+				str = unicode(str, 'utf-8')
+			except UnicodeDecodeError:
+				str = unicode(str, locale.getdefaultlocale()[1])
 		try:
 			# Try to log as unicode, but fall back to ascii (for Windows)
 			termfp.write(str.encode('utf-8'))
 		except UnicodeDecodeError:
-			termfp.write(str.encode('ascii', 'replace'))
+			try:
+				termfp.write(str.encode(locale.getdefaultlocale()[1]))
+			except UnicodeDecodeError:
+				termfp.write(str.encode('ascii', 'replace'))
 
 	def conn(self, direction, result, req_num):
 		"""Log some data on the connection

--- a/rdiff-backup/rdiff_backup/rpath.py
+++ b/rdiff-backup/rdiff_backup/rpath.py
@@ -996,6 +996,7 @@ class RPath(RORPath):
 
 	def rmdir(self):
 		log.Log("Removing directory " + self.path, 6)
+		self.conn.os.chmod(self.path, 0700)
 		self.conn.os.rmdir(self.path)
 		self.data = {'type': None}
 

--- a/rdiff-backup/rdiff_backup/rpath.py
+++ b/rdiff-backup/rdiff_backup/rpath.py
@@ -35,7 +35,7 @@ are dealing with are local or remote.
 
 """
 
-import os, stat, re, sys, shutil, gzip, socket, time, errno, codecs
+import os, stat, re, sys, shutil, gzip, socket, time, errno, codecs, locale
 import Globals, Time, static, log, user_group, C
 
 try:
@@ -1423,23 +1423,36 @@ class MaybeUnicode:
 
 	def __init__(self, fileobj):
 		self.fileobj = fileobj
+		self.defaultCodec = locale.getdefaultlocale()[1]
 
 	def read(self, length = -1):
 		data = self.fileobj.read(length)
 		if Globals.use_unicode_paths:
-			data = unicode(data, 'utf-8')
+			try:
+				data = unicode(data, 'utf-8')
+			except UnicodeDecodeError:
+				# Try again with default locale
+				data = unicode(data, self.defaultCodec)
 		return data
 
 	def readline(self, length=-1):
 		data = self.fileobj.readline(length)
 		if Globals.use_unicode_paths:
-			data = unicode(data, 'utf-8')
+			try:
+				data = unicode(data, 'utf-8')
+			except UnicodeDecodeError:
+				# Try again with default locale
+				data = unicode(data, self.defaultCodec)
 		return data
 
 	def write(self, buf):
 		if Globals.use_unicode_paths:
 			if type(buf) != unicode:
-				buf = unicode(buf, 'utf-8')
+				try:
+					buf = unicode(buf, 'utf-8')
+				except UnicodeDecodeError:
+					# Try again with default locale
+					buf = unicode(buf, self.defaultCodec)
 			buf = buf.encode('utf-8')
 		return self.fileobj.write(buf)
 

--- a/rdiff-backup/rdiff_backup/win_acls.py
+++ b/rdiff-backup/rdiff_backup/win_acls.py
@@ -18,6 +18,7 @@
 # USA
 
 from __future__ import generators
+import locale
 import C, metadata, re, rorpiter, rpath, log
 
 try:
@@ -204,7 +205,14 @@ class ACL:
 			raise metadata.ParsingError("Bad record beginning: " + lines[0][:8])
 		filename = lines[0][8:]
 		if filename == '.': self.index = ()
-		else: self.index = tuple(unicode(C.acl_unquote(filename)).split('/'))
+		else:
+			s = C.acl_unquote(filename)
+			try:
+				s = unicode(s)
+			except UnicodeDecodeError:
+				# Try with default codec
+				s = unicode(s, locale.getdefaultlocale()[1])
+			self.index = tuple(s.split('/'))
 		self.__acl = lines[1]
 
 def Record2WACL(record):


### PR DESCRIPTION
Apparently, rdiff-backup does not take into account the possibility that folders could not be deletable.
This pull request is about adding a call to os.chmod(), that should render modifiable any directory, before attempting to delete it.

Please note that I only tested this patch under Win32.

A simple use case is with folders with custom icons. When the user sets a custom icon on a folder, Windows also sets the "system" attribute on the folder.

I hope this can be useful.